### PR TITLE
fix upperleft coordinates in output

### DIFF
--- a/testing/s2_tiles_supres.py
+++ b/testing/s2_tiles_supres.py
@@ -395,8 +395,14 @@ else:
 
 sys.stdout.write("Writing")
 result_dataset = driver.Create(output_file, data10.shape[1], data10.shape[0], out_dims, gdal.GDT_Float64)
-result_dataset.SetGeoTransform(ds10.GetGeoTransform())
+
+# Translate the image upper left corner. We multiply x10 to transform from pixel position in the 10m_band to meters.
+geot = list(ds10.GetGeoTransform())
+geot[0] += xmin * 10
+geot[3] -= ymin * 10
+result_dataset.SetGeoTransform(tuple(geot))
 result_dataset.SetProjection(ds10.GetProjection())
+
 if copy_original_bands:
     sys.stdout.write(" the original 10m bands and")
     # Write the original 10m bands


### PR DESCRIPTION
Hi Charis,

First of all thanks for sharing the code, the work looks great!
I found a bug in the test script `s2_tiles_supres.py` and wanted to contribute with a fix.

The problem is that when you superresolve only a part of the image (let's say roi_x_y='500,500,2500,2500') the output image has the origin upperleft coordinates equal to the ones in original image, while it should have ori_coord + (500,500).

Let me show you with some images, as it's going to be clearer.

**Original code**

python s2_tiles_supres.py path_to_xml output_file.tif --roi_x_y **"0,0,2500,2500"**
![image](https://user-images.githubusercontent.com/16413205/52436172-da65fa00-2b13-11e9-9be3-03110d84dbdb.png)

python s2_tiles_supres.py path_to_xml output_file.tif --roi_x_y **"500,500,2500,2500"**
![image](https://user-images.githubusercontent.com/16413205/52436198-f36eab00-2b13-11e9-9d4f-2daf54e117b5.png)

**After the changes in this pull request**
python s2_tiles_supres.py path_to_xml output_file.tif --roi_x_y **"500,500,2500,2500"**
![image](https://user-images.githubusercontent.com/16413205/52436225-0bdec580-2b14-11e9-87a7-887a9dcf94f5.png)

I just started using gdal but I hope this fixes the issue.

Thanks again,

Ignacio