### PR TITLE
Modifying the hyperlink  "Open In Colab" in the "Running_Demo_in_the_colab"  notebook

### DIFF
--- a/Running_Demo_in_the_colab.ipynb
+++ b/Running_Demo_in_the_colab.ipynb
@@ -24,7 +24,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/mugheesahmad/DSen2/blob/master/Running_Demo_in_the_colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/lanha/DSen2/blob/master/Running_Demo_in_the_colab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
Changed the hyperlink So that upon clicking the button "Open In Colab" inside the "Running_Demo_in_the_colab" notebook,  Colab  point towards the notebook in  the master branch of  repository.